### PR TITLE
Update go-redis.md

### DIFF
--- a/docs/guide/go-redis.md
+++ b/docs/guide/go-redis.md
@@ -25,7 +25,7 @@ go get github.com/go-redis/redis/v8
 If you are using **Redis 7**, install go-redis/**v9** (currently in beta):
 
 ```shell
-go get github.com/go-redis/redis/v9
+go get github.com/redis/go-redis/v9
 ```
 
 ## Connecting to Redis Server


### PR DESCRIPTION
Fix module path for go get V9
This was causing an issue not allowing for importing go-redis V9